### PR TITLE
Create .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "images/abesstp-web/src"]
   path = images/abesstp-web/src
   url = https://git.abes.fr/depots/abesstp
+  update = merge

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "images/abesstp-web/src"]
+  path = images/abesstp-web/src
+  url = https://git.abes.fr/depots/abesstp


### PR DESCRIPTION
Le fichier images/abesstp-web/src a une syntaxe de sous-répertoire renvoyant vers un sous module git.
Dans certaines opérations, on peut se retrouver avec le message
# git submodule update --init --recursive
fatal: URL non trouvée pour le chemin de sous-module 'images/abesstp-web/src' dans .gitmodules

.gitmodules permet de compléter l'information de dépendance au référentiel interne git.abes.fr. Un utilisateur extérieur à l'Abes aura un simple message d'erreur lui indiquant que ce repo n'est pas accessible sans que cela l'empêche de cloner le reste des sources.
